### PR TITLE
fix: 내가 쓴&스크랩한 글 좋아요 토글링 오류 해결

### DIFF
--- a/routes/users.js
+++ b/routes/users.js
@@ -106,8 +106,8 @@ router.put('/:userId/profile/pw', asyncHandler(async(req, res) => {
 
 
 //마이페이지
-router.get('/:userId/posts', asyncHandler(async(req, res) => {
-  const { userId } = req.params;
+router.get('/posts', asyncHandler(async(req, res) => {
+  const { userId } = req.body;
 
   if (!await User.exists({ _id: userId })) {
     return res.status(404).json({error: "존재하지 않는 회원입니다."});
@@ -147,8 +147,8 @@ router.get('/:userId/comments', asyncHandler(async(req, res) => {
 }))
 
 //스크랩
-router.get('/:userId/scraps', asyncHandler(async (req, res) => {
-  const { userId } = req.params;
+router.get('/scraps', asyncHandler(async (req, res) => {
+  const { userId } = req.body;
 
   if (!await User.exists({ _id: userId })) {
     return res.status(404).json({error: "존재하지 않는 회원입니다."});


### PR DESCRIPTION
기존 문제점: userId를 좋아요 API에서는 body로 받고, 내가 쓴&스크랩한 글에서는 path variable로 받아서 좋아요 기능이 안 됐음
-> 해결: 내가 쓴&스크랩한 글에서는 userId를 body로 받게끔 수정 (url에서 userId가 안 보이게 됨)

* 그래도 해결이 안 되어서 PR close