### PR TITLE
fix: 탈퇴한 유저의 좋아요 표시 에러 해결

### DIFF
--- a/routes/users.js
+++ b/routes/users.js
@@ -89,7 +89,7 @@ router.delete('/delete', passport.authenticate('jwt', {session: false}), asyncHa
   const user = req.user;
   // 내가 만든 컬렉션만 삭제
   await Collection.deleteMany({ user: user._id });
-  // 게시물, 댓글, 좋아요의 user를 null로
+  // 게시물, 댓글의 user를 null로
   const posts = await Post.find({ user: user._id });
   posts.map(async (post) => {
       post.user = null;
@@ -99,11 +99,6 @@ router.delete('/delete', passport.authenticate('jwt', {session: false}), asyncHa
   comments.map(async (comment) => {
       comment.user = null;
       await comment.save();
-  });
-  const likes = await Like.find({ user: user._id });
-  likes.map(async (like) => {
-      like.user = null;
-      await like.save();
   });
   await User.deleteOne(user);
 


### PR DESCRIPTION
좋아요 누른 유저가 회원 탈퇴 시 Like Document의 user 필드를 null로 바꾸어, 
로그아웃 상태(user가 null)에서 전체 게시물 조회 시, 좋아요 여부를 체크할 때 user가 null인 경우와 똑같아져서 true로 보임
-> 회원 탈퇴 시 user를 null로 바꾸지 않고 기존 유저의 ObjectId로 냅둠