### PR TITLE
feat: 배포된 클라이언트와 연결

### DIFF
--- a/app.js
+++ b/app.js
@@ -32,7 +32,7 @@ app.use(express.urlencoded({limit: '100mb', extended: false}));
 
 // cors 처리
 app.use(cors({
-  origin: "http://localhost:3000",  // 접근 권한을 부여하는 도메인
+  origin: ["http://localhost:3000", "https://yeoun.netlify.app"],  // 접근 권한을 부여하는 도메인
   credentials: true,                // 요청에 쿠키 포함시키도록 허용
   allowedHeaders: "Content-Type"    // 허용할 HTTP 헤더 지정
 }));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "yeoun",
-  "version": "0.0.0",
+  "name": "yeoun-server",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "yeoun",
-      "version": "0.0.0",
+      "name": "yeoun-server",
+      "version": "1.0.0",
       "dependencies": {
         "cookie-parser": "~1.4.4",
         "cors": "^2.8.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "yeoun",
-  "version": "0.0.0",
+  "name": "yeoun-server",
+  "version": "1.0.0",
   "private": true,
   "scripts": {
     "start": "node ./bin/www"

--- a/routes/users.js
+++ b/routes/users.js
@@ -72,7 +72,11 @@ router.post('/signin/token', asyncHandler(async (req, res) => {
           // 유저 jwt 생성 - jwt.sign('token 내용', 'JWT secretkey')
           const token = jwt.sign({id: user._id}, process.env.JWT_SECRET, {expiresIn: '1 year'});
           // 토큰 쿠키로 전달
-          res.cookie('token', token);
+          res.cookie('token', token, {
+            sameSite: "None",     // SameSite 설정
+            secure: true,         // HTTPS에서만 전송
+            httpOnly: true,       // JavaScript에서 접근 불가
+          });
           return res.json({user, token});
       });
   })(req, res);


### PR DESCRIPTION
- 접근 가능한 도메인에 배포된 클라이언트 도메인 추가
- 배포된 클라이언트와 연결 시 인증이 필요한 기능이 잘 작동되지 않음 -> 쿠키의 Same Site 옵션을 설정해서 해결
- 버전 1.0.0부터 시작 (버그 및 기타 수정 시 숫자 증가시키기)