### PR TITLE
chore: GCP 배포를 위한 추가

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,0 +1,6 @@
+runtime: nodejs18
+env: standard
+
+handlers:
+- url: /.*
+  script: auto


### PR DESCRIPTION
- Koyeb으로 배포하였으나 속도 저하 문제로 GCP (Google Cloud Platform)를 활용하여 서버 성능 및 속도 향상